### PR TITLE
Specify file types for XML grammar

### DIFF
--- a/grammars/property list (xml).cson
+++ b/grammars/property list (xml).cson
@@ -1,4 +1,10 @@
-'fileTypes': []
+'fileTypes': [
+  'plist'
+  'dict'
+  'scriptSuite'
+  'scriptTerminology'
+  'savedSearch'
+]
 'firstLineMatch': '\\s*<\\?xml .*\\n\\s*<!DOCTYPE\\s*(?i:plist)\\s'
 'name': 'Property List (XML)'
 'patterns': [


### PR DESCRIPTION
By specifying file types on both grammars, the deciding tie-breaker will be firstLineMatch.

See https://github.com/atom/language-property-list/issues/5#issuecomment-214506152 for detailed explanation.

Fixes #5
