### PR TITLE
Add Workflow files

### DIFF
--- a/grammars/property list (xml).cson
+++ b/grammars/property list (xml).cson
@@ -4,6 +4,7 @@
   'scriptSuite'
   'scriptTerminology'
   'savedSearch'
+  'wflow'
 ]
 'firstLineMatch': '\\s*<\\?xml .*\\n\\s*<!DOCTYPE\\s*(?i:plist)\\s'
 'name': 'Property List (XML)'


### PR DESCRIPTION
Automator Workflows store their configuration in a `.wflow` property list inside the `*.workflow/Contents` folder.

As suggested in this [pull-request](https://github.com/atom/language-xml/pull/73) for `language-xml`, I'm adding `.wflow` here instead. Unfortunately, documentation is scarce, but I've found the file-format mentioned on the Apple Developer website [this once](https://developer.apple.com/reference/automator/1566971-nserror_codes/amworkflowpropertylistinvaliderror?language=objc). There are also several Automator Workflows on GitHub, e.g. [this](https://github.com/sparanoid/automator-workflows).

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Adds file-extension for `.wflow` property lists

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Workflow files get highlighted in Atom

